### PR TITLE
Add a default propagation format to override in inject and extract

### DIFF
--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -29,7 +29,8 @@ module Jaeger
                    flush_interval: DEFAULT_FLUSH_INTERVAL,
                    sampler: Samplers::Const.new(true),
                    logger: Logger.new(STDOUT),
-                   sender: nil)
+                   sender: nil,
+                   propagation_default: nil)
       encoder = Encoders::ThriftEncoder.new(service_name: service_name)
 
       if sender.nil?
@@ -37,7 +38,7 @@ module Jaeger
       end
 
       reporter = AsyncReporter.create(sender: sender, flush_interval: flush_interval)
-      Tracer.new(reporter, sampler)
+      Tracer.new(reporter, sampler, propagation_default)
     end
   end
 end

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -30,7 +30,7 @@ module Jaeger
                    sampler: Samplers::Const.new(true),
                    logger: Logger.new(STDOUT),
                    sender: nil,
-                   propagation_default: nil)
+                   propagation_override: nil)
       encoder = Encoders::ThriftEncoder.new(service_name: service_name)
 
       if sender.nil?
@@ -38,7 +38,7 @@ module Jaeger
       end
 
       reporter = AsyncReporter.create(sender: sender, flush_interval: flush_interval)
-      Tracer.new(reporter, sampler, propagation_default)
+      Tracer.new(reporter, sampler, propagation_override: propagation_override)
     end
   end
 end

--- a/lib/jaeger/client/tracer.rb
+++ b/lib/jaeger/client/tracer.rb
@@ -3,10 +3,10 @@
 module Jaeger
   module Client
     class Tracer
-      def initialize(reporter, sampler, propagation_default)
+      def initialize(reporter, sampler, propagation_override: nil)
         @reporter = reporter
         @sampler = sampler
-        @propagation_default = propagation_default # used to override any specified propagation format
+        @propagation_override = propagation_override # used to override any specified propagation format
         @scope_manager = ScopeManager.new
       end
 
@@ -128,7 +128,7 @@ module Jaeger
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       def inject(span_context, format, carrier)
-        case @propagation_default || format
+        case @propagation_override || format
         when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_RACK
           carrier['uber-trace-id'] = [
             span_context.trace_id.to_s(16),
@@ -147,7 +147,7 @@ module Jaeger
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       # @return [SpanContext] the extracted SpanContext or nil if none could be found
       def extract(format, carrier)
-        case @propagation_default || format
+        case @propagation_override || format
         when OpenTracing::FORMAT_TEXT_MAP
           parse_context(carrier['uber-trace-id'])
         when OpenTracing::FORMAT_RACK


### PR DESCRIPTION
This will allow us to set the default to B3 in the agent, rather than updating all the instrumentation to use a different format instead.